### PR TITLE
Create custom exception class

### DIFF
--- a/src/exceptions/InvalidRefParamException.php
+++ b/src/exceptions/InvalidRefParamException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace craft\templateguard\exceptions;
+
+use Exception;
+
+class InvalidRefParamException extends \RuntimeException implements Exception
+{
+}

--- a/src/exceptions/InvalidRefParamException.php
+++ b/src/exceptions/InvalidRefParamException.php
@@ -2,8 +2,9 @@
 
 namespace jorenvanhee\templateguard\exceptions;
 
-use Exception;
+use yii\web\BadRequestHttpException;
 
-class InvalidRefParamException extends \RuntimeException implements Exception
+
+class InvalidRefParamException extends BadRequestHttpException
 {
 }

--- a/src/exceptions/InvalidRefParamException.php
+++ b/src/exceptions/InvalidRefParamException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace craft\templateguard\exceptions;
+namespace jorenvanhee\templateguard\exceptions;
 
 use Exception;
 

--- a/src/services/GuardService.php
+++ b/src/services/GuardService.php
@@ -8,7 +8,6 @@ use craft\helpers\UrlHelper;
 use jorenvanhee\templateguard\Plugin;
 use jorenvanhee\templateguard\exceptions\InvalidRefParamException;
 use yii\base\Component;
-use yii\web\BadRequestHttpException;
 use yii\web\Cookie;
 
 class GuardService extends Component

--- a/src/services/GuardService.php
+++ b/src/services/GuardService.php
@@ -6,6 +6,7 @@ use Craft;
 use InvalidArgumentException;
 use craft\helpers\UrlHelper;
 use jorenvanhee\templateguard\Plugin;
+use jorenvanhee\templateguard\exceptions\InvalidRefParamException;
 use yii\base\Component;
 use yii\web\BadRequestHttpException;
 use yii\web\Cookie;
@@ -53,7 +54,7 @@ class GuardService extends Component
         );
 
         if ($ref === false) {
-            throw new BadRequestHttpException('The ref query param is missing or invalid.');
+            throw new InvalidRefParamException('The ref query param is missing or invalid.');
         }
 
         return $ref;


### PR DESCRIPTION
Adds a custom exception class that is thrown instead of the BadRequestHttpException if a ref param is missing or has been tampered with.

This is to make it easier to identify, and if desired to filter, the exception in logs since they are so easy for a front-end user to trigger.